### PR TITLE
Fix Readme bugs

### DIFF
--- a/packages/keyboard-navigation/README.md
+++ b/packages/keyboard-navigation/README.md
@@ -41,8 +41,8 @@ keyboard events.
 
 ```jsx
 import { createKeyboardNav, KeyboardNav } from 'aria-keyboard-a11y'
-const tabs = KeyboardNav('horizontal')
-const useKeyboardNav = createKeyboardNav(tabs)
+const tabs = new KeyboardNav('horizontal')
+const useKeyboardNav = createKeyboardNavHook(tabs)
 
 function Tab({ label, title, setActiveTabs, isSelected = false, index = 0 }) {
   function handleKeyDown(event) {


### PR DESCRIPTION
The KeyboardNav hook was missing the new keyword in the readme
The create createKeyboardNavHook was named createKeyboardNav which was also not currently correct.

 I'll probably want to shorten or rename in the future!